### PR TITLE
Environment setup

### DIFF
--- a/environment.js.example
+++ b/environment.js.example
@@ -21,6 +21,9 @@ const ENV = {
   }
 };
 
+// Constants.manifest.releaseChannel may only be available in prod
+const releaseChannel = !__DEV__ ? Constants.manifest.releaseChannel : null;
+
 const getEnvVars = (env = Constants.manifest.releaseChannel) => {
  if (__DEV__) {
    return ENV.dev;

--- a/environment.js.example
+++ b/environment.js.example
@@ -1,4 +1,4 @@
-import { Constants } from "expo";
+import Constants from "expo-constants";
 import { Platform } from "react-native";
 
 const localhost = Platform.OS === "ios" ? "localhost:8080" : "10.0.2.2:8080";
@@ -21,10 +21,7 @@ const ENV = {
   }
 };
 
-// Constants.manifest.releaseChannel may only be available in prod
-const releaseChannel = !__DEV__ ? Constants.manifest.releaseChannel : null;
-
-const getEnvVars = (env = releaseChannel) => {
+const getEnvVars = (env = Constants.manifest.releaseChannel) => {
  if (__DEV__) {
    return ENV.dev;
  } else if (env === 'staging') {

--- a/environment.js.example
+++ b/environment.js.example
@@ -24,7 +24,7 @@ const ENV = {
 // Constants.manifest.releaseChannel may only be available in prod
 const releaseChannel = !__DEV__ ? Constants.manifest.releaseChannel : null;
 
-const getEnvVars = (env = Constants.manifest.releaseChannel) => {
+const getEnvVars = (env = releaseChannel) => {
  if (__DEV__) {
    return ENV.dev;
  } else if (env === 'staging') {


### PR DESCRIPTION
In dev was getting an error `not an object` in reference to `_expo.Constants.manifest.releaseChannel`. Not sure if anyone else has encountered this issue. 

One work around from [here](https://forums.expo.io/t/getting-release-channel-in-app/5300/10) suggested the change I made in this pr. 

If this is wrong but the issue still persists, another workaround is changing `import { Constants } from 'expo'` to `import Constants from 'expo-constants'`